### PR TITLE
Feat/reworked entrypoint

### DIFF
--- a/.github/workflows/publish_docker_hub.yml
+++ b/.github/workflows/publish_docker_hub.yml
@@ -27,11 +27,11 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           push: true
-          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/github-actions-self-hosted-runner:${{ github.event.release.tag_name }}
+          tags: ${{ secrets.DOCKER_USERNAME  }}/github-actions-self-hosted-runner:${{ github.event.release.tag_name }}
 
       - name: Build and push (manual)
         if: github.event_name == 'workflow_dispatch'
         uses: docker/build-push-action@v6
         with:
           push: true
-          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/github-actions-self-hosted-runner:latest
+          tags: ${{ secrets.DOCKER_USERNAME  }}/github-actions-self-hosted-runner:latest

--- a/.github/workflows/publish_docker_hub.yml
+++ b/.github/workflows/publish_docker_hub.yml
@@ -22,8 +22,16 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build and push
+      - name: Build and push (release)
+        if: github.event_name == 'release'
         uses: docker/build-push-action@v6
         with:
           push: true
-          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/github-actions-self-hosted-runner:${{ github.event_name == 'workflow_dispatch' && 'latest' || github.event.release.tag_name }},${{ github.event_name != 'workflow_dispatch' && secrets.DOCKER_HUB_USERNAME + '/github-actions-self-hosted-runner:latest' || '' }}
+          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/github-actions-self-hosted-runner:${{ github.event.release.tag_name }}
+
+      - name: Build and push (manual)
+        if: github.event_name == 'workflow_dispatch'
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/github-actions-self-hosted-runner:latest

--- a/.github/workflows/publish_docker_hub.yml
+++ b/.github/workflows/publish_docker_hub.yml
@@ -26,6 +26,4 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           push: true
-          tags: |
-            shatnord/github-actions-self-hosted-runner:latest
-            shatnord/github-actions-self-hosted-runner:${{ github.event.release.tag_name }}
+          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/github-actions-self-hosted-runner:${{ github.event_name == 'workflow_dispatch' && 'latest' || github.event.release.tag_name }},${{ github.event_name != 'workflow_dispatch' && secrets.DOCKER_HUB_USERNAME + '/github-actions-self-hosted-runner:latest' || '' }}


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/publish_docker_hub.yml` file to differentiate between release and manual builds. The most important changes include adding conditional statements to handle different event types and updating the tags used for Docker images.

Changes to the workflow:

* [`.github/workflows/publish_docker_hub.yml`](diffhunk://#diff-98b9259226a8b31f6610343a25ce9d4c90b30073162ecd74889c51bd2521fd95L25-R37): Added conditional statements to handle 'release' and 'workflow_dispatch' events separately. The 'release' event builds and pushes Docker images with the release tag, while the 'workflow_dispatch' event builds and pushes the latest Docker image.