### PR TITLE
Update publish_docker_hub.yml

### DIFF
--- a/.github/workflows/publish_docker_hub.yml
+++ b/.github/workflows/publish_docker_hub.yml
@@ -27,7 +27,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           push: true
-          tags: ${{ secrets.DOCKER_USERNAME  }}/github-actions-self-hosted-runner:${{ github.event.release.tag_name }}
+          tags: ${{ secrets.DOCKER_USERNAME  }}/github-actions-self-hosted-runner:${{ github.event.release.tag_name }}, ${{ secrets.DOCKER_USERNAME  }}/github-actions-self-hosted-runner:latest
 
       - name: Build and push (manual)
         if: github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
This pull request includes a change to the Docker Hub publishing workflow to ensure the latest release is tagged appropriately.

* [`.github/workflows/publish_docker_hub.yml`](diffhunk://#diff-98b9259226a8b31f6610343a25ce9d4c90b30073162ecd74889c51bd2521fd95L30-R30): Modified the `tags` parameter to include both the release tag and the `latest` tag for Docker images.